### PR TITLE
add dokuwiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Ansible config and a bunch of Docker containers.
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies
 * [Deluge](https://dev.deluge-torrent.org/) - A lightweight, Free Software, cross-platform BitTorrent client.
+* [DokuWiki](https://www.dokuwiki.org/) - A simple to use and highly versatile Open Source wiki software that doesn't require a database.
 * [Duplicati](https://www.duplicati.com/) - for backing up your stuff
 * [Emby](https://emby.media/) - Media streaming and management
 * [Firefly III](https://firefly-iii.org/) - Free and open source personal finance manager

--- a/docs/applications/dokuwiki.md
+++ b/docs/applications/dokuwiki.md
@@ -1,0 +1,11 @@
+# DokuWiki
+
+Homepage: [https://www.dokuwiki.org/](https://www.dokuwiki.org/)
+
+DokuWiki is a simple to use and highly versatile Open Source wiki software that doesn't require a database. It is loved by users for its clean and readable syntax. The ease of maintenance, backup and integration makes it an administrator's favorite. Built in access controls and authentication connectors make DokuWiki especially useful in the enterprise context and the large number of plugins contributed by its vibrant community allow for a broad range of use cases beyond a traditional wiki.
+
+## Usage
+
+Set `dokuwiki_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The DokuWiki web interface can be found at http://ansible_nas_host_or_ip:8085.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -11,6 +11,7 @@ By default, applications can be found on the ports listed below.
 | Calibre-web     | 8084    | Bridge  | HTTP           |
 | Cloud Commander | 7373    | Bridge  | HTTP           |
 | Couchpotato     | 5050    | Bridge  | HTTP           |
+| DokuWiki        | 8085    | Bridge  | HTTP           |
 | Duplicati       | 8200    | Bridge  | HTTP           |
 | Emby            | 8096    | Bridge  | HTTP           |
 | Emby            | 8096    | Bridge  | HTTP           |

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -51,6 +51,9 @@ ubooquity_enabled: false
 # Joomla
 joomla_enabled: false
 
+# Wiki
+dokuwiki_enabled: false
+
 # PyTivo
 pytivo_enabled: false
 
@@ -302,6 +305,14 @@ gitlab_port_ssh: "422"
 guacamole_available_externally: "false"
 guacamole_data_directory: "{{ docker_home }}/guacamole"
 guacamole_port: "8090"
+
+###
+### DokuWiki
+###
+dokuwiki_available_externally: "false"
+dokuwiki_hostname: "dokuwiki"
+dokuwiki_data_directory: "{{ docker_home }}/dokuwiki"
+dokuwiki_port: "8085"
 
 ###
 ### Krusader

--- a/nas.yml
+++ b/nas.yml
@@ -332,3 +332,7 @@
     - import_tasks: tasks/pytivo.yml
       when: (pytivo_enabled | default(False))
       tags: pytivo
+
+    - import_tasks: tasks/dokuwiki.yml
+      when: (dokuwiki_enabled | default(False))
+      tags: dokuwiki

--- a/tasks/dokuwiki.yml
+++ b/tasks/dokuwiki.yml
@@ -1,0 +1,26 @@
+---
+- name: Create DokuWiki Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ dokuwiki_data_directory }}/data"
+
+- name: DokuWiki Docker Container
+  docker_container:
+    name: dokuwiki
+    image: linuxserver/dokuwiki:latest
+    pull: true
+    volumes:
+      - "{{ dokuwiki_data_directory }}:/config/dokuwiki/data:rw"
+    ports:
+      - "{{ dokuwiki_port }}:80"
+    restart_policy: unless-stopped
+    memory: 1g
+    labels:
+      traefik.enable: "{{ dokuwiki_available_externally }}"
+      traefik.http.routers.dokuwiki.rule: "Host(`{{ dokuwiki_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.dokuwiki.tls.certresolver: "letsencrypt"
+      traefik.http.routers.dokuwiki.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.dokuwiki.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.dokuwiki.loadbalancer.server.port: "{{ dokuwiki_port }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add DokuWiki, an Open Source wiki that doesn't require a database

**Any other useful info**:

Simple to use. Allows edits of content files directly. Used as a personal wiki for notes.